### PR TITLE
Add openocd option to RevB settings

### DIFF
--- a/generate_settings.py
+++ b/generate_settings.py
@@ -126,7 +126,7 @@ def type2tag(target_type):
     if "arty" in target_type or "vc707" in target_type or "vcu118" in target_type:
         tags = "fpga openocd"
     elif "hifive1-revb" in target_type:
-        tags = "board jlink"
+        tags = "board jlink openocd"
     elif "rtl" in target_type:
         tags = "rtl"
     elif "spike" in target_type:


### PR DESCRIPTION
With https://github.com/riscv/riscv-openocd/pull/456, the RevB now has OpenOCD support. Add tag to settings.mk to allow use in freedom-e-sdk.

This also requires makefile changes to key off of, but this will need to be merged first I think before the freedom-e-sdk bsp CI tests will pass.