### PR TITLE
Use wake 'here' to make install path source location flexible

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -76,6 +76,9 @@ global target installESDKSettingsGenerator installPath =
     source "{here}/LICENSE",
     source "{here}/generate_settings.py",
     Nil
-
+  def installWithStructure dir file =
+    def oneDown = simplify "{here}/.."
+    def into = "{dir}/{relative oneDown file.getPathName}"
+    installAs into file
   mkdir installPath,
-  map (installIn installPath) generatorSources
+  map (installWithStructure installPath) generatorSources


### PR DESCRIPTION
`installIn` is defined as 
```
export def installIn dir file =
  installAs "{dir}/{file.getPathName}" file
```

When used with Wit, the `getPathName` would include only the repository name, for example:
```
installIn "builddir" pathToSomeFile -> builddir/esdk-settings-generator/somefile.sh
```
When the wake rule is used via git submodules a longer path is inserted, for example
```
installIn "builddir" pathToSomeFile -> builddir/freedom-e-sdk/software/esdk-settings-generator/somefile.sh
```
This PR aims to resolve the inconsistency by using `here/..` to capture the repository name directly, thus preserving the paths in `builddir`