### PR TITLE
[ESAT-379] generate_settings.py: keep the "c" in "rv32emc" for gcc -march

### DIFF
--- a/generate_settings.py
+++ b/generate_settings.py
@@ -80,7 +80,7 @@ def arch2arch(arch):
     # pylint: disable=too-many-return-statements
     if arch == "rv32ea":
         return "rv32e"
-    if arch in ["rv32ema", "rv32emc"]:
+    if arch in ["rv32ema"]:
         return "rv32em"
 
     if arch == "rv32ia":


### PR DESCRIPTION
In the Llama timeframe (early 2021), the toolchain folks got
permission from product management to drop any multilib that didn't
include compressed instruction support.  This however conflicts with
this code from esdk-settings-generator from early 2020 (if not
earlier):

83:    if arch in ["rv32ema", "rv32emc"]:
84:        return "rv32em"

... which rewrites a "rv32emc" arch string to "rv32em".

(from https://github.com/sifive/esdk-settings-generator/blob/master/generate_settings.py#L83)

There aren't any comments associated with that code.  So it's hard to
tell why it was added.  My assumption is that the toolchain originally
didn't support "rv32emc" as a multilib, but did support "rv32em".  But
now, as of Llama, the situation is reversed: we support "rv32emc" but
not "rv32em".  So, drop the code that maps "rv32emc" -> "rv32em".