### PR TITLE
Roll back -march workarounds

### DIFF
--- a/generate_settings.py
+++ b/generate_settings.py
@@ -92,12 +92,6 @@ def arch2arch(arch):
         return "rv64i"
     if arch == "rv64ima":
         return "rv64im"
-    # Handle here until DTS correctly generating *_zfh
-    if arch == "rv64imafdcv":
-        return "rv64imafdcv_zfh"
-
-    if arch in ["rv64imafdcv_zba_zbb_zfh_xsfvqmaccqoq_xsfvfhbfmin"]:
-        return "rv64imafdcv_zba_zbb_zfh_xsfvqmaccqoq"
 
     return arch
 


### PR DESCRIPTION
This generator was previously modified by
* adding `zfh` to certain targets' `arch`-strings, to work around missing support in our DTS generator, and
* removing `xsfvfhbfmin` from certain targets' `arch`-strings, to work around missing support in our toolchain.

The reasons for these workarounds have been addressed elsewhere, so these hacks are no longer necessary.