### PR TITLE
[ESAT-424] FESDK-public: modify esdk-settings-generator to set TARGET_CORE_ITERS to 110000 for Unmatched

### DIFF
--- a/generate_settings.py
+++ b/generate_settings.py
@@ -213,6 +213,9 @@ def main(argv):
         core_iters = 5000
         freertos_wait_ms = 1000
 
+    if "unmatched" in parsed_args.type:
+        core_iters = 110000
+
     settings = """# Copyright (C) 2020 SiFive Inc
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Set TARGET_CORE_ITERS to 110000 for Unmatched to allow coremark to run without an error that it didn’t run long enough. After this patch is merged, we would go on to FESDK PR to include the patch that bumps esdk-settings-generator submodule.